### PR TITLE
Convert to use a single table

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,19 @@
 Monitors Slack for messages that refer to a Pull Request. When that Pull Request
 is approved, adds a reaction emoji to each of the messages that mentioned it.
 
+## How it works
+
+1. Slack sends a POST to the service's `/slack` endpoint any time a `github.com` URL is mentioned.
+The service records that mention as Pull Request URL, the Slack channel the message was posted in,
+and the timestamp of the message (which is Slack's unique identifier).
+
+2. GitHub sends a POST to the service's `/github` endpoint any time a Pull Request is approved.
+The service records the Pull Request URL as an approval.
+
+3. The system makes an API call to Slack to add a reaction emoji to each mention of an approved Pull Request.
+
+> * Note that steps 1 and 2 can happen in any order, and both will trigger step 3.
+
 ## Development requirements
 
 Install serverless globally

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Install the ruby gems
 bundle install --standalone --path vendor/bundle
 ```
 
+You also need to have a Docker daemon running if you attempt to deploy. The
+first deploy may take a long time as the Docker image used to compile native
+gems is downloaded.
+
 ## Deployment
 
 > Make sure you follow the instructions for Initial Deployment Configuration

--- a/lib/approval.rb
+++ b/lib/approval.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Approval
+  module PrimaryKey
+    SORT_KEY = "approved"
+
+    def self.call(pr_id)
+      {
+        "part_key": pr_id,
+        "sort_key": SORT_KEY
+      }
+    end
+  end
+end

--- a/lib/mention.rb
+++ b/lib/mention.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Mention
+  module PrimaryKey
+    PREFIX = "mention:"
+
+    def self.call(pr_id, mention_id)
+      {
+        part_key: pr_id,
+        sort_key: PREFIX + mention_id,
+      }
+    end
+  end
+end

--- a/lib/pull_request_identifier.rb
+++ b/lib/pull_request_identifier.rb
@@ -9,8 +9,11 @@ class PullRequestIdentifier
     new
   end
 
+  PR_ID_REGEX = /github\.com\/(.+?)\/(.+?)\/pull\/\d+/i
   def call(url)
-    _protocol, pr_id = url.split("://", 2)
-    pr_id
+    match = PR_ID_REGEX.match(url)
+    if match
+      match.to_s.downcase
+    end
   end
 end

--- a/lib/settings.rb
+++ b/lib/settings.rb
@@ -9,7 +9,10 @@ class Settings
   def self.configure(namespace, other)
     @values.each do |key, value|
       setting_ns, setting = key.split("_", 2)
-      if setting_ns.downcase == namespace
+      if setting.nil?
+        setting, setting_ns = setting_ns, setting
+      end
+      if setting_ns.nil? || (setting_ns.downcase == namespace)
         method_name = "#{setting.downcase}=".to_sym
         if other.respond_to?(method_name)
           other.public_send(method_name, value)

--- a/lib/slack_event_received.rb
+++ b/lib/slack_event_received.rb
@@ -49,13 +49,17 @@ class SlackEventReceived
       }
       if github_links.length == 1
         url = github_links[0].fetch("url")
-        logger << "Storing a mention of #{url}"
         pr_id = PullRequestIdentifier.(url)
-        channel = slack_event.fetch("channel")
-        message_ts = slack_event.fetch("message_ts")
-        mention_id = "#{channel}|#{message_ts}"
-        mentions_store.save(pr_id: pr_id, mention_id: mention_id)
-        invoke_mark_pr_approved.(pr_id)
+        if pr_id
+          logger << "Storing a mention of #{url}"
+          channel = slack_event.fetch("channel")
+          message_ts = slack_event.fetch("message_ts")
+          mention_id = "#{channel}|#{message_ts}"
+          mentions_store.save(pr_id: pr_id, mention_id: mention_id)
+          invoke_mark_pr_approved.(pr_id)
+        else
+          logger << "Not a pull request link: #{url}"
+        end
       else
         logger << "Not storing an ambiguous mention. Links: #{github_links}"
       end

--- a/serverless.yml
+++ b/serverless.yml
@@ -14,12 +14,20 @@ provider:
     App: ${self:service}
 
   environment:
-    PRAPPROVED_TABLE_NAME: ${self:service}-${self:provider.stage}-PullRequestApprovals
-    MENTIONS_TABLE_NAME: ${self:service}-${self:provider.stage}-PullRequestMentions
+    TABLE: ${self:service}-${self:provider.stage}
     MENTIONS_TTL: 2592000 # 30 days
     SLACK_TOKEN: ${env:SLACK_TOKEN}
 
   iamRoleStatements:
+    # Give our lambda permission to write to our dynamodb table
+    - Sid: DynamoReadWriteAccess
+      Effect: Allow
+      Action:
+        - dynamodb:GetItem
+        - dynamodb:Query
+        - dynamodb:PutItem
+      Resource:
+         "Fn::GetAtt": [ PRCheckTable, Arn ]
     # Give our lambda permission to store events in the mentions dynamodb table
     - Sid: MentionsReadWriteAccess
       Effect: Allow
@@ -80,6 +88,22 @@ functions:
 
 resources:
   - Resources:
+      #The DynamoDB table that stores the services data
+      PRCheckTable:
+        Type: AWS::DynamoDB::Table
+        Properties:
+          TableName: ${self:service}-${self:provider.stage}
+          AttributeDefinitions:
+            - AttributeName: part_key
+              AttributeType: S
+            - AttributeName: sort_key
+              AttributeType: S
+          KeySchema:
+            - AttributeName: part_key
+              KeyType: HASH
+            - AttributeName: sort_key
+              KeyType: RANGE
+          BillingMode: PAY_PER_REQUEST
       #The DynamoDB table where we keep track of PRs that have been approved
       PullRequestApprovalsTable:
         Type: AWS::DynamoDB::Table

--- a/serverless.yml
+++ b/serverless.yml
@@ -28,24 +28,7 @@ provider:
         - dynamodb:PutItem
       Resource:
          "Fn::GetAtt": [ PRCheckTable, Arn ]
-    # Give our lambda permission to store events in the mentions dynamodb table
-    - Sid: MentionsReadWriteAccess
-      Effect: Allow
-      Action:
-        - dynamodb:GetItem
-        - dynamodb:Query
-        - dynamodb:PutItem
-      Resource:
-         "Fn::GetAtt": [ PullRequestMentionsTable, Arn ]
-    # Give our lambda permission to store events in the approvals dynamodb table
-    - Sid: ApprovalsReadWriteAccess
-      Effect: Allow
-      Action:
-        - dynamodb:GetItem
-        - dynamodb:Query
-        - dynamodb:PutItem
-      Resource:
-         "Fn::GetAtt": [ PullRequestApprovalsTable, Arn ]
+    # Give our lambda permission to invoke any other lambda in this service
     - Sid: MarkInvocation
       Effect: Allow
       Action:
@@ -102,34 +85,6 @@ resources:
             - AttributeName: part_key
               KeyType: HASH
             - AttributeName: sort_key
-              KeyType: RANGE
-          BillingMode: PAY_PER_REQUEST
-      #The DynamoDB table where we keep track of PRs that have been approved
-      PullRequestApprovalsTable:
-        Type: AWS::DynamoDB::Table
-        Properties:
-          TableName: ${self:service}-${self:provider.stage}-PullRequestApprovals
-          AttributeDefinitions:
-            - AttributeName: pr_id
-              AttributeType: S
-          KeySchema:
-            - AttributeName: pr_id
-              KeyType: HASH
-          BillingMode: PAY_PER_REQUEST
-      #The DynamoDB table where we keep track of Slack messages that mention PRs
-      PullRequestMentionsTable:
-        Type: AWS::DynamoDB::Table
-        Properties:
-          TableName: ${self:service}-${self:provider.stage}-PullRequestMentions
-          AttributeDefinitions:
-            - AttributeName: pr_id
-              AttributeType: S
-            - AttributeName: mention_id
-              AttributeType: S
-          KeySchema:
-            - AttributeName: pr_id
-              KeyType: HASH
-            - AttributeName: mention_id
               KeyType: RANGE
           BillingMode: PAY_PER_REQUEST
           TimeToLiveSpecification:

--- a/spec/pull_request_identifier_spec.rb
+++ b/spec/pull_request_identifier_spec.rb
@@ -1,0 +1,28 @@
+require "pull_request_identifier"
+
+RSpec.describe "PullRequestIdentifier" do
+  context "when the URL refers to a pull request" do
+    let(:url){
+      "https://github.com/ExampleOrg/example-Repo/pull/42"
+    }
+
+    it "returns a lower-cased portion of the URL without the scheme" do
+      pr_id = PullRequestIdentifier.(url)
+
+      expect(pr_id).to eq("github.com/exampleorg/example-repo/pull/42")
+    end
+
+  end
+
+  context "when the URL does not refer to a pull request" do
+    let(:url){
+      "https://github.com/ExampleOrg/example-Repo/blob/ac69b4dc74fdf94ce4f3d8ae113f7f3c2d6eec25/fruits.txt"
+    }
+
+    it "returns nil" do
+      pr_id = PullRequestIdentifier.(url)
+
+      expect(pr_id).to be_nil
+    end
+  end
+end

--- a/spec/settings_spec.rb
+++ b/spec/settings_spec.rb
@@ -8,14 +8,15 @@ RSpec.describe "Settings" do
       "OWNER_AGE" => 42,
       "OWNER_Phone" => "555-1212",
       "OWNER_ZIP_CODE" => "90210",
-      "WEIGHT" => 120,
-      "HEIGHT" => 72,
+      "PLANET" => "earth",
+      "OTHER_WEIGHT" => 120,
+      "OTHER_HEIGHT" => 72,
     }
 
     Settings.init(configuration_values)
 
     example_class = Class.new do
-      attr_accessor :name, :age, :zipcode, :weight, :height
+      attr_accessor :name, :age, :zipcode, :weight, :height, :planet
       attr_reader :phone
     end
 
@@ -29,5 +30,6 @@ RSpec.describe "Settings" do
     expect(instance.phone).to be_nil # no setter
     expect(instance.weight).to be_nil # no namespace
     expect(instance.height).to be_nil # wrong namespace
+    expect(instance.planet).to eq("earth") # global namespace
   end
 end


### PR DESCRIPTION
From AWS Best Practices for DynamoDB:

> In general, you should maintain as few tables as possible in a DynamoDB
application. Most well-designed applications require only one table.
Exceptions include cases where high-volume time series data are involved,
or datasets that have very different access patterns. A single table with
inverted indexes can usually enable simple queries to create and retrieve
the complex hierarchical data structures required by your application.

https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/bp-modeling-nosql.html

Also, stop counting all Github links as mentions. Only capture links to Pull Requests.
Normalize the pull request URLs (lower-case, and remove any additional path/querystring)
so that we can always match exactly on the partition key.